### PR TITLE
Fixes scaffolding month and year populating config

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,9 +21,11 @@ Opinionated scaffolding and static site generator for storytelling.
 
 *See [Setup](#setup) for recommended local install.*
 
+By default `machinist init` will automatically set the generated project's month and year. 
+
 1. Install [Node.js](https://nodejs.org/) (v8.x required)
 1. `npm install -g @nbcnews/machinist`
-1. `machinist init <project-name>`
+1. `machinist init <project-name> <optional-explicit-month: MM> <optional-explicit-year: YYYY>`
 1. `npm i`
 1. `npm run dev`
 1. Visit [`http://localhost:3000`](http://localhost:3000)
@@ -41,18 +43,20 @@ Opinionated scaffolding and static site generator for storytelling.
 
 You can either scaffold using the globally installed Machinist or scaffold locally.
 
+By default `machinist init` will automatically set the generated project's month and year. 
+
 Install locally (recommended)
 
 1. `cd` into an empty project directory
 1. `npm install @nbcnews/machinist`
-1. `$(npm bin)/machinist init <project-name>`
+1. `$(npm bin)/machinist init <project-name> <optional-explicit-month: MM> <optional-explicit-year: YYYY>`
 1. `npm install`
 
 Install globally 
 
 1. `npm install -g @nbcnews/machinist`
 1. `cd` into an empty project directory
-1. `machinist init <project-name>`
+1. `machinist init <project-name> <optional-explicit-month: MM> <optional-explicit-year: YYYY>`
 1. `npm install`
 
 ## How To Use

--- a/bin/initialize.js
+++ b/bin/initialize.js
@@ -13,13 +13,13 @@ var outputFiles = [
 
 function projectInit (program) {
   const projectName = program.init
-  let month = program.args[0] || new Date().getMonth() + 1
+  let month = program.args[1] || new Date().getMonth() + 1
 
   if (month.toString().length === 1) {
     month = '0' + month
   }
 
-  const year = program.args[1] || new Date().getYear() + 1900
+  const year = program.args[2] || new Date().getYear() + 1900
   const data = { projectName, month, year }
 
   console.log('## DEBUG data:', data)


### PR DESCRIPTION
Fixes scaffold bug where "project name" arg was populating the month.

Project name is argument one, then month and last year.

cc. @bradoyler 